### PR TITLE
Update installation instructions in README with explicit installation paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,15 @@ Amsa uses metadata from the following sources:
 Installation
 ============
 1. Get the latest source zip in github release for Amsa https://github.com/Dingmatt/AMSA/releases.
-2. Place the content of the zip (Plug-in Support, Plug-ins, Scanners) into your Plex Media Server directory 
-3. Create a new library 
-4. Set its scanner to "Absolute Series Scanner"
-5. Set its agent to "Anime Multi Source Agent"
-6. Access the Amsa settings from your server library admin tab
+2. Place the content of the zip (Plug-in Support, Plug-ins, Scanners) into your Plex Media Server directory
+   - Windows: `%LOCALAPPDATA%\Plex Media Server\Plug-ins`
+   - macOS: `~/Library/Application Support/Plex Media Server/Plug-ins`
+   - Linux: `$PLEX_HOME/Library/Application Support/Plex Media Server/Plug-ins`
+   - More info: [Plex Documentation](https://support.plex.tv/articles/201106098-how-do-i-find-the-plug-ins-folder/)
+4. Create a new library 
+5. Set its scanner to "Absolute Series Scanner"
+6. Set its agent to "Anime Multi Source Agent"
+7. Access the Amsa settings from your server library admin tab
 
 
 

--- a/README.md
+++ b/README.md
@@ -27,10 +27,10 @@ Installation
    - macOS: `~/Library/Application Support/Plex Media Server/Plug-ins`
    - Linux: `$PLEX_HOME/Library/Application Support/Plex Media Server/Plug-ins`
    - More info: [Plex Documentation](https://support.plex.tv/articles/201106098-how-do-i-find-the-plug-ins-folder/)
-4. Create a new library 
-5. Set its scanner to "Absolute Series Scanner"
-6. Set its agent to "Anime Multi Source Agent"
-7. Access the Amsa settings from your server library admin tab
+3. Create a new library 
+4. Set its scanner to "Absolute Series Scanner"
+5. Set its agent to "Anime Multi Source Agent"
+6. Access the Amsa settings from your server library admin tab
 
 
 


### PR DESCRIPTION
I've installed your plugin today but it didn't occur to me that the Plex Media Server directory mentioned in the installation instructions was not the one in Program Files (on Windows) but the one in Local AppData! I wasted a good while trying to understand why the plugin was not loading when it simply was not in the right directory... So I'm proposing this simple change to help first-timers like me :)